### PR TITLE
Error in tests of string multiplication task

### DIFF
--- a/introduction_course/lesson3/task2/tests.py
+++ b/introduction_course/lesson3/task2/tests.py
@@ -5,7 +5,8 @@ def test_value():
     file = import_task_file()
     if hasattr(file, "ten_of_hellos") and file.ten_of_hellos == "hellohellohellohellohellohellohellohellohellohello":
         passed()
-    failed("Use multiplication")
+    else:
+        failed("Use multiplication")
 
 def test_window():
     window = get_answer_placeholders()[0]


### PR DESCRIPTION
While trying out PyCharm Edu to learn Python I noticed that the string multiplication task would not accept my answer even though it was correct. Trying around a little I finally found that an "else:" was missing from the test, making it always fail.